### PR TITLE
Changed loading message parent

### DIFF
--- a/source
+++ b/source
@@ -6,7 +6,7 @@ end
 pcall(function() getgenv().IY_LOADED  = true end)
 
 if not game:IsLoaded() then
-	local notLoaded = Instance.new("Message",workspace)
+	local notLoaded = Instance.new("Message", game:GetService("CoreGui"))
 	notLoaded.Text = 'Infinite Yield is waiting for the game to load'
 	game.Loaded:Wait()
 	notLoaded:Destroy()


### PR DESCRIPTION
Changed loading message parent to coregui from workspace. it still displays in gui containers.