### PR TITLE
Makes loadfile run in a seperate thread

### DIFF
--- a/source
+++ b/source
@@ -6283,7 +6283,7 @@ function LoadPlugin(val,startup)
 	local plugin
 
 	function CatchedPluginLoad()
-		plugin = loadfile(val)()
+		plugin = coroutine.wrap(loadfile(val))()
 	end
 
 	function handlePluginError(plerror)


### PR DESCRIPTION
Allows the loadfile to run in a seperate thread so if the plugin has any sort of yield, infinite yield source will not be affected by it.