### PR TITLE
Band-aid: Check outgoing HTTP requests for known malicious plugin domains

### DIFF
--- a/source
+++ b/source
@@ -30,7 +30,10 @@ end
 local DebugLog = _G.IY_DEBUG and (function()
   local env = getgenv();
   local CreateConsole = env.consolecreate or env.rconsolecreate;
-  local PrintConsole = env.consoleprint or env.rconsoleprint or
+  local consoleprint = env.consoleprint or env.rconsoleprint
+  local PrintConsole = consoleprint and function(...)
+    return consoleprint(table.concat({...},' ')..'\n')
+  end or
                            function( ... ) print('IY_DEBUG:', ...) end
   local SetConsoleTitle = env.consolesettitle or env.rconsolesettitle or
                               function() end
@@ -43,6 +46,11 @@ local DebugLog = _G.IY_DEBUG and (function()
     PrintConsole(...)
   end
 end)() or function() end
+local NewLogger = _G.IY_DEBUG and function(name)
+  return function(logText,...)
+    DebugLog('<'.. name ..'> '..tostring(logText),...)
+  end
+end or function()end
 
 -- Hook HTTP
 local BlacklistedKeywords = {
@@ -54,12 +62,15 @@ local IsMakeCClosure = typeof(newcclosure) == 'function'
 
 -- Run HTTP hooks in seperate thread (dw coroutines are roblox globals, all executors *should* support them)
 coroutine.resume(coroutine.create(function()
+  local Logger = NewLogger('HTTP Hooks')
+  Logger('Created Logger')
   local env = getgenv();
   local MakeCClosure = IsMakeCClosure and newcclosure or function() end
   local IsCClosure = env.iscclosure or
                          (env.islclosure and
                              function( v ) return not islclosure(v) end) or
                          function() return true end
+  Logger('Got CClosure Create/Check Functions')
   -- Function to hook HTTP Requests
   local HookFunction = function( table, key, scanner )
     if not table or not key or not table.key then return false end
@@ -98,6 +109,7 @@ coroutine.resume(coroutine.create(function()
       end
     end
   end
+  Logger('Got Scanner')
   -- Format:
   -- k,v where k is the table, and v contains CClosure (if we should convert to cclosures) and Attr (a list of attributes)
   local HTTPFunctions = {
@@ -107,24 +119,35 @@ coroutine.resume(coroutine.create(function()
     };
     [game:GetService('HttpService')] = { 'GetAsync'; 'PostAsync';
                                          'RequestAsync' };
-    [env.syn or {}] = {
+    [env.syn or 'syn global (not found)'] = {
       'Request'; -- weird attempts at compatability be like
       'request';
     };
-    [env.http or {}] = { 'request' };
+    [env.http or 'http global (not found)'] = { 'request' };
     [env] = { 'http_request'; 'request' };
   };
+  Logger('Got Data.')
+  Logger('Hooking HTTP Functions')
   for table, props in pairs(HTTPFunctions) do
-    for _, prop in pairs(props) do
-      if HookFunction(table, prop, Scanner) then
-        DebugLog('Infinite Yield has hooked ' .. prop .. ' in ' ..
-                     tostring(table))
-      else
-        DebugLog('Infinite Yield did not hook ' .. prop .. ' in ' ..
-                     tostring(table))
+    warn(typeof(table));
+    if typeof(table) == 'string' then
+      Logger('Not Hooking Table: ' .. table)
+    else
+      local Logger = NewLogger('HTTP Hooks > ' .. tostring(table))
+      Logger('Hooking Table',table,'('..#props..' entries)')
+      for _, prop in pairs(props) do
+        Logger('Hooking',prop)
+        if HookFunction(table, prop, Scanner) then
+          Logger('Infinite Yield has hooked ' .. prop .. ' in ' ..
+                      tostring(table))
+        else
+          Logger('Infinite Yield did not hook ' .. prop .. ' in ' ..
+                      tostring(table))
+        end
       end
     end
   end
+  Logger('Done Hooking!')
 end))
 
 -- Load IY

--- a/source
+++ b/source
@@ -28,6 +28,7 @@ end
 
 -- Debug Logging
 local DebugLog = _G.IY_DEBUG and (function()
+  local env = getgenv();
   local CreateConsole = env.consolecreate or env.rconsolecreate;
   local PrintConsole = env.consoleprint or env.rconsoleprint or
                            function( ... ) print('IY_DEBUG:', ...) end

--- a/source
+++ b/source
@@ -178,7 +178,7 @@ coroutine.resume(coroutine.create(function()
       Name = 'HTTPService';
       Table = game:GetService('HttpService');
       Data = { 'GetAsync'; 'PostAsync'; 'RequestAsync' };
-    }; {
+    }; --[[{
       Name = 'Syn Global';
       Table = env.syn;
       Data = {
@@ -186,7 +186,7 @@ coroutine.resume(coroutine.create(function()
         'request';
       };
     }; { Name = 'HTTP Global'; Table = env.http; Data = { 'request' } };
-    { Name = 'Globals'; Table = env; Data = { 'http_request'; 'request' } };
+    { Name = 'Globals'; Table = env; Data = { 'http_request'; 'request' } };]]
   };
   Logger('Got Data.')
   Logger('Hooking HTTP Functions')

--- a/source
+++ b/source
@@ -116,7 +116,7 @@ coroutine.resume(coroutine.create(function()
             if checkcaller() and Self == Table and NamecallMethod == key then
               local URL = scanner(...);
               if not URL then
-                return OldNameCall(...)
+                return OldNameCall(Self,...)
               else
                 warn(
                     'HTTP Request to ' .. (URL or '<Scan did not return URL>') ..

--- a/source
+++ b/source
@@ -49,7 +49,7 @@ local NewLogger = _G.IY_DEBUG and function( name )
   return function( logText, ... )
     DebugLog('<' .. name .. '> ' .. tostring(logText), ...)
   end
-end or function() end
+end or function() return function()end end
 
 -- Hook HTTP
 local BlacklistedKeywords = {
@@ -80,7 +80,7 @@ coroutine.resume(coroutine.create(function()
         local OldMethod = Table[key]
         if not OldMethod then return false end
         local oldWriteState = getreadonly(Table)
-        warn(oldWriteState)
+        -- warn(oldWriteState)
         local setWritable = makewritable and makereadonly and
                                 function( t, s )
               return (s and makewritable or makereadonly)(t);

--- a/source
+++ b/source
@@ -1,20 +1,133 @@
+
+-- Define Version
+local ver = '5.7'
+
+-- Ensure IY isn't already running (debounce check)
 if IY_LOADED and not _G.IY_DEBUG == true then
-	error("Infinite Yield is already running!",0)
-	return
+  error('Infinite Yield is already running!', 0)
+  return
 end
 
+-- Define Environment Getter Funtion
+local getgenv = getgenv or getfenv or function()
+  return
+      _ENV --[[ for lua5.3 executors which I was told exist for some reason ]] or
+          {} --[[ for executors with no env functions (just incase) ]]
+end
+
+-- Ensure IY wont run again (debounce set)
 pcall(function() getgenv().IY_LOADED = true end)
 
+-- Ensure game is loaded
 if not game:IsLoaded() then
-	local notLoaded = Instance.new("Message", game:GetService("CoreGui"))
-	notLoaded.Text = 'Infinite Yield is waiting for the game to load'
-	game.Loaded:Wait()
-	notLoaded:Destroy()
+  local notLoaded = Instance.new('Message', game:GetService('CoreGui'))
+  notLoaded.Text = 'Infinite Yield is waiting for the game to load'
+  game.Loaded:Wait()
+  notLoaded:Destroy()
 end
 
-ver = '5.7'
+-- Debug Logging
+local DebugLog = _G.IY_DEBUG and (function()
+  local CreateConsole = env.consolecreate or env.rconsolecreate;
+  local PrintConsole = env.consoleprint or env.rconsoleprint or
+                           function( ... ) print('IY_DEBUG:', ...) end
+  local SetConsoleTitle = env.consolesettitle or env.rconsolesettitle or
+                              function() end
+  return function( ... )
+    if CreateConsole then
+      CreateConsole();
+      SetConsoleTitle('Infinite Yield Debug Log');
+      CreateConsole = nil
+    end
+    PrintConsole(...)
+  end
+end)() or function() end
 
-Players = game:GetService("Players")
+-- Hook HTTP
+local BlacklistedKeywords = {
+  -- List of blacklisted strings for URLs
+  'ligma.wtf'; 'blocked.example.com'; 'malplugin.yieldingcoder.repl.co'
+}
+local IsKRNL = KRNL_LOADED -- left over from previous itterations of http hooks, left in for future use in other things
+local IsMakeCClosure = typeof(newcclosure) == 'function'
+
+-- Run HTTP hooks in seperate thread (dw coroutines are roblox globals, all executors *should* support them)
+coroutine.resume(coroutine.create(function()
+  local env = getgenv();
+  local MakeCClosure = IsMakeCClosure and newcclosure or function() end
+  local IsCClosure = env.iscclosure or
+                         (env.islclosure and
+                             function( v ) return not islclosure(v) end) or
+                         function() return true end
+  -- Function to hook HTTP Requests
+  local HookFunction = function( table, key, scanner )
+    if not table or not key or not table.key then return false end
+    local OldMethod
+    OldMethod = hookfunction(table.key,
+                             (IsCClosure(table[key]) and MakeCClosure or
+                                 function( v ) return v; end)(function( ... )
+      local URL = scanner(...);
+      if not URL then
+        return OldMethod(...)
+      else
+        warn('HTTP Request to ' .. (URL or '<Scan did not return URL>') ..
+                 ' Blocked by Infinite Yield.')
+        return nil, 'HTTP request blocked by Infinite Yield'
+      end
+    end))
+    return true;
+  end
+  -- Utility Function; Removes the k in a k,v pair
+  local RemoveKey = function( t )
+    local t2 = {};
+    for _, v in pairs(t) do table.insert(t2, v) end
+    return t2
+  end
+  -- Scanner function; checks all strings - if is a table, recursively scans, otherwise checks for blacklisted strings
+  local Scanner = function( ... )
+    local Args = { ... }
+    for i, v in pairs(Args) do
+      if typeof(v) == 'table' then
+        Scanner(unpack(unorder(v)))
+      else
+        v = string.lower(tostring(v))
+        for _, searchFor in pairs(BlacklistedKeywords) do
+          if v:find(searchFor) then return v end
+        end
+      end
+    end
+  end
+  -- Format:
+  -- k,v where k is the table, and v contains CClosure (if we should convert to cclosures) and Attr (a list of attributes)
+  local HTTPFunctions = {
+    [game] = {
+      'HttpGetAsync'; 'HttpPostAsync'; 'HttpRequestAsync'; 'HttpGet';
+      'HttpPost'; 'HttpRequest';
+    };
+    [game:GetService('HttpService')] = { 'GetAsync'; 'PostAsync';
+                                         'RequestAsync' };
+    [env.syn or {}] = {
+      'Request'; -- weird attempts at compatability be like
+      'request';
+    };
+    [env.http or {}] = { 'request' };
+    [env] = { 'http_request'; 'request' };
+  };
+  for table, props in pairs(HTTPFunctions) do
+    for _, prop in pairs(props) do
+      if HookFunction(table, prop, Scanner) then
+        DebugLog('Infinite Yield has hooked ' .. prop .. ' in ' ..
+                     tostring(table))
+      else
+        DebugLog('Infinite Yield did not hook ' .. prop .. ' in ' ..
+                     tostring(table))
+      end
+    end
+  end
+end))
+
+-- Load IY
+local Players = game:GetService('Players')
 
 Holder = Instance.new("Frame")
 Title = Instance.new("TextLabel")

--- a/source
+++ b/source
@@ -1,4 +1,3 @@
-
 -- Define Version
 local ver = '5.7'
 
@@ -31,10 +30,10 @@ local DebugLog = _G.IY_DEBUG and (function()
   local env = getgenv();
   local CreateConsole = env.consolecreate or env.rconsolecreate;
   local consoleprint = env.consoleprint or env.rconsoleprint
-  local PrintConsole = consoleprint and function(...)
-    return consoleprint(table.concat({...},' ')..'\n')
-  end or
-                           function( ... ) print('IY_DEBUG:', ...) end
+  local PrintConsole = consoleprint and
+                           function( ... )
+        return consoleprint(table.concat({ ... }, ' ') .. '\n')
+      end or function( ... ) print('IY_DEBUG:', ...) end
   local SetConsoleTitle = env.consolesettitle or env.rconsolesettitle or
                               function() end
   return function( ... )
@@ -46,16 +45,16 @@ local DebugLog = _G.IY_DEBUG and (function()
     PrintConsole(...)
   end
 end)() or function() end
-local NewLogger = _G.IY_DEBUG and function(name)
-  return function(logText,...)
-    DebugLog('<'.. name ..'> '..tostring(logText),...)
+local NewLogger = _G.IY_DEBUG and function( name )
+  return function( logText, ... )
+    DebugLog('<' .. name .. '> ' .. tostring(logText), ...)
   end
-end or function()end
+end or function() end
 
 -- Hook HTTP
 local BlacklistedKeywords = {
   -- List of blacklisted strings for URLs
-  'ligma.wtf'; 'blocked.example.com'; 'malplugin.yieldingcoder.repl.co'
+  'ligma.wtf'; 'blocked.example.com'; 'malplugin.yieldingcoder.repl.co';
 }
 local IsKRNL = KRNL_LOADED -- left over from previous itterations of http hooks, left in for future use in other things
 local IsMakeCClosure = typeof(newcclosure) == 'function'
@@ -72,22 +71,73 @@ coroutine.resume(coroutine.create(function()
                          function() return true end
   Logger('Got CClosure Create/Check Functions')
   -- Function to hook HTTP Requests
-  local HookFunction = function( table, key, scanner )
-    if not table or not key or not table.key then return false end
-    local OldMethod
-    OldMethod = hookfunction(table.key,
-                             (IsCClosure(table[key]) and MakeCClosure or
-                                 function( v ) return v; end)(function( ... )
-      local URL = scanner(...);
-      if not URL then
-        return OldMethod(...)
+  local HookFunction = function( Table, key, scanner )
+    local getreadonly = function( t ) return isreadonly(t) end
+    -- pcalled due to shit executors that don't support read/write control
+    local a, b = pcall(function()
+      if not Table then return false end
+      if string.lower(type(Table)) ~= 'userdata' or not hookmetamethod then
+        local OldMethod = Table[key]
+        if not OldMethod then return false end
+        local oldWriteState = getreadonly(Table)
+        warn(oldWriteState)
+        local setWritable = makewritable and makereadonly and
+                                function( t, s )
+              return (s and makewritable or makereadonly)(t);
+            end or setreadonly and
+                                function( t, s )
+              return setreadonly(t, not s);
+            end
+        if setWritable then setWritable(Table, false) end
+        local NewMethod = (IsCClosure(OldMethod) and MakeCClosure or
+                              function( v ) return v; end)(function( ... )
+          local URL = scanner(...);
+          if not URL then
+            return OldMethod(...)
+          else
+            warn('HTTP Request to ' .. (URL or '<Scan did not return URL>') ..
+                     ' Blocked by Infinite Yield.')
+            return nil, 'HTTP request blocked by Infinite Yield'
+          end
+        end)
+        Table[key] = NewMethod;
+        if oldWriteState and setWritable then
+          setWritable(Table, oldWriteState)
+        end
+        return true;
       else
-        warn('HTTP Request to ' .. (URL or '<Scan did not return URL>') ..
-                 ' Blocked by Infinite Yield.')
-        return nil, 'HTTP request blocked by Infinite Yield'
+        if checkcaller and getnamecallmethod then
+          local OldNameCall = nil
+
+          OldNameCall = hookmetamethod(Table, '__namecall',
+                                       function( Self, ... )
+            local NamecallMethod = getnamecallmethod()
+
+            if checkcaller() and Self == Table and NamecallMethod == key then
+              local URL = scanner(...);
+              if not URL then
+                return OldNameCall(...)
+              else
+                warn(
+                    'HTTP Request to ' .. (URL or '<Scan did not return URL>') ..
+                        ' Blocked by Infinite Yield.')
+                return nil, 'HTTP request blocked by Infinite Yield'
+              end
+            end
+
+            return OldNameCall(Self,...)
+          end)
+          return true
+        else
+          return false
+        end
       end
-    end))
-    return true;
+    end)
+    if not a then
+      if _G.IY_DEBUG then warn('err during hook:', b) end
+    else
+      return b;
+    end
   end
   -- Utility Function; Removes the k in a k,v pair
   local RemoveKey = function( t )
@@ -96,11 +146,15 @@ coroutine.resume(coroutine.create(function()
     return t2
   end
   -- Scanner function; checks all strings - if is a table, recursively scans, otherwise checks for blacklisted strings
-  local Scanner = function( ... )
+  local ScanLogger = NewLogger('HTTP Scanner')
+  local Scanner
+  Scanner = function( ... )
+    ScanLogger('Scanning...')
     local Args = { ... }
     for i, v in pairs(Args) do
+      ScanLogger('Scan', i, v)
       if typeof(v) == 'table' then
-        Scanner(unpack(unorder(v)))
+        Scanner(unpack(RemoveKey(v)))
       else
         v = string.lower(tostring(v))
         for _, searchFor in pairs(BlacklistedKeywords) do
@@ -113,36 +167,44 @@ coroutine.resume(coroutine.create(function()
   -- Format:
   -- k,v where k is the table, and v contains CClosure (if we should convert to cclosures) and Attr (a list of attributes)
   local HTTPFunctions = {
-    [game] = {
-      'HttpGetAsync'; 'HttpPostAsync'; 'HttpRequestAsync'; 'HttpGet';
-      'HttpPost'; 'HttpRequest';
-    };
-    [game:GetService('HttpService')] = { 'GetAsync'; 'PostAsync';
-                                         'RequestAsync' };
-    [env.syn or 'syn global (not found)'] = {
-      'Request'; -- weird attempts at compatability be like
-      'request';
-    };
-    [env.http or 'http global (not found)'] = { 'request' };
-    [env] = { 'http_request'; 'request' };
+    {
+      Name = 'Game';
+      Table = game;
+      Data = {
+        'HttpGetAsync'; 'HttpPostAsync'; 'HttpRequestAsync'; 'HttpGet';
+        'HttpPost'; 'HttpRequest';
+      };
+    }; {
+      Name = 'HTTPService';
+      Table = game:GetService('HttpService');
+      Data = { 'GetAsync'; 'PostAsync'; 'RequestAsync' };
+    }; {
+      Name = 'Syn Global';
+      Table = env.syn;
+      Data = {
+        'Request'; -- weird attempts at compatability be like
+        'request';
+      };
+    }; { Name = 'HTTP Global'; Table = env.http; Data = { 'request' } };
+    { Name = 'Globals'; Table = env; Data = { 'http_request'; 'request' } };
   };
   Logger('Got Data.')
   Logger('Hooking HTTP Functions')
-  for table, props in pairs(HTTPFunctions) do
-    warn(typeof(table));
-    if typeof(table) == 'string' then
-      Logger('Not Hooking Table: ' .. table)
+  for i, data in pairs(HTTPFunctions) do
+    local Props = data.Data;
+    local Table = data.Table;
+    Logger('Loop:', i, '(' .. data.Name .. ' / ' .. #Props .. ' possible props)')
+    if not Table then
+      Logger('Not Hooking Table: ' .. data.Name .. ' (Not Found)')
     else
-      local Logger = NewLogger('HTTP Hooks > ' .. tostring(table))
-      Logger('Hooking Table',table,'('..#props..' entries)')
-      for _, prop in pairs(props) do
-        Logger('Hooking',prop)
-        if HookFunction(table, prop, Scanner) then
-          Logger('Infinite Yield has hooked ' .. prop .. ' in ' ..
-                      tostring(table))
+      local Logger = NewLogger('HTTP Hooks > ' .. tostring(data.Name))
+      Logger('Hooking Table ' .. data.Name .. ' (' .. #Props .. ' entries)')
+      for _, prop in pairs(Props) do
+        Logger('Hooking', prop)
+        if HookFunction(Table, prop, Scanner) then
+          Logger('Infinite Yield has hooked ' .. prop .. ' in ' .. data.Name)
         else
-          Logger('Infinite Yield did not hook ' .. prop .. ' in ' ..
-                      tostring(table))
+          Logger('Infinite Yield did not hook ' .. prop .. ' in ' .. data.Name)
         end
       end
     end

--- a/source
+++ b/source
@@ -6281,23 +6281,10 @@ end
 local PluginCache
 function LoadPlugin(val,startup)
 	local plugin
-    local pluginfunc
 
 	function CatchedPluginLoad()
-        pluginfunc = loadfile(val)
-		plugin = pluginfunc()
+		plugin = coroutine.wrap(loadfile(val))()
 	end
-
-    local pluginsource = readfile(val)
-
-    local bannedkeywords = {"loadstring"}
-
-    for i,v in pairs(bannedkeywords) do
-        if pluginsource:match(v) then
-            notify('Plugin Error', 'Banned keywords found in plugin. For safety reasons the plugin will not be loaded. Check the discord for more information.')
-            return false
-        end
-    end
 
 	function handlePluginError(plerror)
 		notify('Plugin Error','An error occurred with the plugin, "'..val..'" and it could not be loaded')
@@ -6321,8 +6308,6 @@ function LoadPlugin(val,startup)
 	xpcall(CatchedPluginLoad, handlePluginError)
 
 	if plugin ~= nil then
-        getfenv(pluginfunc).loadstring = function() return nil, '' end
-        
 		if not startup then
 			notify('Loaded Plugin',"Name: "..plugin["PluginName"].."\n".."Description: "..plugin["PluginDescription"])
 		end
@@ -6450,7 +6435,7 @@ addcmd('clraliases',{},function(args, speaker)
 end)
 
 addcmd('discord', {'support', 'help'}, function(args, speaker)
-	local http = game:GetService('HttpService') 
+	local rhttp = game:GetService('HttpService') 
 	if toClipboard then
 		toClipboard('https://discord.com/invite/dYHag43eeU')
 		notify('Discord Invite', 'Copied to clipboard!\ndiscord.gg/dYHag43eeU')
@@ -6466,9 +6451,9 @@ addcmd('discord', {'support', 'help'}, function(args, speaker)
 				['Content-Type'] = 'application/json',
 				Origin = 'https://discord.com'
 			},
-			Body = http:JSONEncode({
+			Body = rhttp:JSONEncode({
 				cmd = 'INVITE_BROWSER',
-				nonce = http:GenerateGUID(false),
+				nonce = rhttp:GenerateGUID(false),
 				args = {code = 'dYHag43eeU'}
 			})
 		})

--- a/source
+++ b/source
@@ -1,5 +1,5 @@
 -- Define Version
-local ver = '5.7'
+local ver = '5.7.1'
 
 -- Ensure IY isn't already running (debounce check)
 if IY_LOADED and not _G.IY_DEBUG == true then

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-Version = '5.7'
+Version = '5.7.1'
 Announcement = ''


### PR DESCRIPTION
This PR fixes the whole ligma.wtf issue (and makes it easy to fix it if they move to another domain) without breaking loadstring.
Unlike the loadstring patch, this **shouldn't** break any non-malicious plugins.
However, it's still very much a band-aid fix.