### PR TITLE
Added excludeFullGames param to serverhop query

### DIFF
--- a/source
+++ b/source
@@ -6652,7 +6652,7 @@ addcmd('serverhop',{'shop'},function(args, speaker)
 	-- thanks to NoobSploit for fixing
 	if httprequest then
 		local servers = {}
-		local req = httprequest({Url = string.format("https://games.roblox.com/v1/games/%d/servers/Public?sortOrder=Desc&limit=100", PlaceId)})
+		local req = httprequest({Url = string.format("https://games.roblox.com/v1/games/%d/servers/Public?sortOrder=Desc&limit=100&excludeFullGames=true", PlaceId)})
 		local body = HttpService:JSONDecode(req.Body)
 		if body and body.data then
 			for i, v in next, body.data do


### PR DESCRIPTION
That pr will resolve an issue when 100 fetched servers are full and you can't jump at noone of them.

https://games.roblox.com/docs/json/v2?urls.primaryName=Games%20Api%20v1
![image](https://github.com/EdgeIY/infiniteyield/assets/153901936/dacb62fe-97ee-4623-b90f-e51036964eed)
