### PR TITLE
Fix fireproximityprompt

### DIFF
--- a/source
+++ b/source
@@ -10652,7 +10652,7 @@ addcmd('noproximitypromptlimits',{'nopplimits','removepplimits'},function(args, 
 end)
 
 addcmd('fireproximityprompts',{'firepp'},function(args, speaker)
-	if fireclickdetector then
+	if fireproximityprompt then
 		if args[1] then
 			local name = getstring(1)
 			for _, descendant in ipairs(workspace:GetDescendants()) do


### PR DESCRIPTION
infinite yield checks if the executor supports fireclickdetector instead of fireproximityprompt