### PR TITLE
change 'joindate' commands to use Player.AccountAge

### DIFF
--- a/source
+++ b/source
@@ -8773,13 +8773,14 @@ end)
 addcmd('joindate',{'jd'},function(args, speaker)
 	local players = getPlayer(args[1], speaker)
 	local dates = {}
-	notify("Loading",'Hold on a sec')
 	for i,v in pairs(players) do
-		local user = game:HttpGet("https://users.roblox.com/v1/users/"..Players[v].UserId)
-		local json = HttpService:JSONDecode(user)
-		local date = json["created"]:sub(1,10)
-		local splitDates = string.split(date,"-")
-		table.insert(dates,Players[v].Name.." joined: "..splitDates[2].."/"..splitDates[3].."/"..splitDates[1])
+		local p = Players[v]
+
+		local secondsOld = p.AccountAge * 60 * 24 * 24
+		local now = os.time()
+		local dateJoined  = p.Name .. " joined: " .. os.date("%m/%d/%y", now - secondsOld)
+
+		table.insert(dates, dateJoined)
 	end
 	notify('Join Date (Month/Day/Year)',table.concat(dates, ',\n'))
 end)
@@ -8787,13 +8788,14 @@ end)
 addcmd('chatjoindate',{'cjd'},function(args, speaker)
 	local players = getPlayer(args[1], speaker)
 	local dates = {}
-	notify("Loading",'Hold on a sec')
 	for i,v in pairs(players) do
-		local user = game:HttpGet("https://users.roblox.com/v1/users/"..Players[v].UserId)
-		local json = HttpService:JSONDecode(user)
-		local date = json["created"]:sub(1,10)
-		local splitDates = string.split(date,"-")
-		table.insert(dates,Players[v].Name.." joined: "..splitDates[2].."/"..splitDates[3].."/"..splitDates[1])
+		local p = Players[v]
+
+		local secondsOld = p.AccountAge * 60 * 24 * 24
+		local now = os.time()
+		local dateJoined  = p.Name .. " joined: " .. os.date("%m/%d/%y", now - secondsOld)
+
+		table.insert(dates, dateJoined)
 	end
 	local chatString = table.concat(dates, ', ')
 	chatMessage(chatString)

--- a/source
+++ b/source
@@ -8776,7 +8776,7 @@ addcmd('joindate',{'jd'},function(args, speaker)
 	for i,v in pairs(players) do
 		local p = Players[v]
 
-		local secondsOld = p.AccountAge * 60 * 24 * 24
+		local secondsOld = p.AccountAge * 24 * 60 * 60
 		local now = os.time()
 		local dateJoined  = p.Name .. " joined: " .. os.date("%m/%d/%y", now - secondsOld)
 
@@ -8791,7 +8791,7 @@ addcmd('chatjoindate',{'cjd'},function(args, speaker)
 	for i,v in pairs(players) do
 		local p = Players[v]
 
-		local secondsOld = p.AccountAge * 60 * 24 * 24
+		local secondsOld = p.AccountAge * 24 * 60 * 60
 		local now = os.time()
 		local dateJoined  = p.Name .. " joined: " .. os.date("%m/%d/%y", now - secondsOld)
 


### PR DESCRIPTION
Replaced the slow http api calls with Player.AccountAge property for much faster and more reliable join date lookups