### PR TITLE
make ;goto use pivots instead

### DIFF
--- a/source
+++ b/source
@@ -8970,13 +8970,17 @@ addcmd("goto", {"to"}, function(args, speaker)
     local character = speaker and speaker.Character
     local humanoid = character and character:FindFirstChildWhichIsA("Humanoid")
     local players = getPlayer(args[1], speaker)
-    for _, v in pairs(players) do
+    for _, v in players do
         if Players[v].Character ~= nil then
             if humanoid and humanoid.SeatPart then
                 humanoid.Sit = false
                 task.wait(0.1)
             end
-            getRoot(speaker.Character).CFrame = getRoot(Players[v].Character):GetPivot() + Vector3.new(3, 1, 0)
+            if workspace.StreamingEnabled then
+                speaker:RequestStreamAroundAsync(Vector3.new(speaker.Character:GetPivot()), 0.1)
+                RunService.Heartbeat:Wait()
+            end
+            speaker.Character:PivotTo(Players[v].Character:GetPivot() + Vector3.new(3, 1, 0))
         end
     end
     execCmd("breakvelocity")


### PR DESCRIPTION
credits to https://discord.com/channels/503045718102114305/551846012310782014/1477005127586939044 (inf yield discord)

p.s. the RequestStreamAroundAsync is just to make the other player's character potentially stream in before teleporting